### PR TITLE
Update Super Tux Kart source to 1.4

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,8 +142,8 @@ parts:
     override-pull: |
       snapcraftctl pull
       sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/128x128/apps/supertuxkart.png|' data/supertuxkart.desktop
-      curl -L -o cacert.patch https://github.com/supertuxkart/stk-code/commit/9bf537ab351f165555048fbc5df88193d8cd70f2.patch
-      patch -Np1 -i cacert.patch
+
+
     parse-info: [usr/share/metainfo/supertuxkart.appdata.xml]
     configflags:
     - -DCMAKE_INSTALL_PREFIX=/usr

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: supertuxkart
-version: '1.3'
+version: '1.4'
 adopt-info: supertuxkart
 
 grade: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,8 +142,6 @@ parts:
     override-pull: |
       snapcraftctl pull
       sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/128x128/apps/supertuxkart.png|' data/supertuxkart.desktop
-
-
     parse-info: [usr/share/metainfo/supertuxkart.appdata.xml]
     configflags:
     - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
Fixes #21 

- Upstream Source:
   - https://github.com/supertuxkart/stk-code/releases/tag/1.4

If my assumption is correct we may get a test snap built from this PR, based on https://github.com/diddlesnaps/supertuxkart/blob/master/.github/workflows/build-prs.yml